### PR TITLE
We shouldn't add config.root to categoryPath.

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -31,7 +31,7 @@ module.exports = function(locals){
   
   var results = [];
   for (var key in items) {
-    var categoryPath = config.root + config.category_dir + '/' + key + '/' + feedConfig.path;
+    var categoryPath = config.category_dir + '/' + key + '/' + feedConfig.path;
     if (feedConfig.limit) {
       items[key].length = feedConfig.limit;
     }


### PR DESCRIPTION
hexo does it on its own, so we get weird paths like
`./public/blog/categories/computer/atom.xml`

https://github.com/\
ninjatools/hexo-generator-category-feed/issues/1#issuecomment-113966808
